### PR TITLE
Add extra_hosts to docker-compose.yml for outside file fetch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,8 @@ services:
       - week_2
     networks:
       - dagster_network
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   content:
     build:


### PR DESCRIPTION
The fetch to s3 data was broken for some docker on linux builds. This fixes that issue for some linux distros, although not all unfortunately.